### PR TITLE
Add syntax highlighting to usage examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,20 @@ Installation
 
 Install using composer:
 
-	composer require jenssegers/agent
+```bash
+composer require jenssegers/agent
+```
 
 Add the service provider in `app/config/app.php`:
 
-	'Jenssegers\Agent\AgentServiceProvider',
+```php
+'Jenssegers\Agent\AgentServiceProvider',
+```
 
 And add the Agent alias to `app/config/app.php`:
-
-	'Agent'            => 'Jenssegers\Agent\Facades\Agent',
+```php
+'Agent' => 'Jenssegers\Agent\Facades\Agent',
+```
 
 Basic Usage
 -----------
@@ -31,31 +36,39 @@ All of the original [Mobile Detect](https://github.com/serbanghita/Mobile-Detect
 
 Check for a certain property in the user agent.
 
-	Agent::is('Windows');
-	Agent::is('Firefox');
-	Agent::is('iPhone');
-	Agent::is('OS X');
+```php
+Agent::is('Windows');
+Agent::is('Firefox');
+Agent::is('iPhone');
+Agent::is('OS X');
+```
 
 ### Magic is-method
 
 Magic method that does the same as the previous `is()` method:
 
-	Agent::isAndroidOS();
-	Agent::isNexus();
-	Agent::isSafari();
+```php
+Agent::isAndroidOS();
+Agent::isNexus();
+Agent::isSafari();
+```
 
 ### Mobile detection
 
 Check for mobile device:
 
-	Agent::isMobile();
-	Agent::isTablet();
+```php
+Agent::isMobile();
+Agent::isTablet();
+```
 
 ### Match user agent
 
 Search the user agent with a regular expression:
 
-	Agent::match('regexp');
+```php
+Agent::match('regexp');
+```
 
 Additional Functionality
 ------------------------
@@ -66,32 +79,42 @@ Since the original library was inspired on CodeIgniter, I decided to add some ad
 
 Get the browser's accept languages. Example:
 
-	$languages = Agent::languages();
-	// ['nl-nl', 'nl', 'en-us', 'en']
+```php
+$languages = Agent::languages();
+// ['nl-nl', 'nl', 'en-us', 'en']
+```
 
 ### Device name
 
 Get the device name, if mobile. (iPhone, Nexus, AsusTablet, ...)
 
-	Agent::device();
+```php
+Agent::device();
+```
 
 ### Operating system name
 
 Get the operating system. (Ubuntu, Windows, OS X, ...)
 
-	Agent::platform();
+```php
+Agent::platform();
+```
 
 ### Browser name
 
 Get the browser name. (Chrome, IE, Safari, Firefox, ...)
 
-	Agent::browser();
-
+```php
+Agent::browser();
+```
+	
 ### Desktop detection
 
 Check if the user is a desktop.
 
-	Agent::isDesktop();
+```php
+Agent::isDesktop();
+```
 
 *This checks if a user is not a mobile device, tablet or robot.*
 
@@ -99,16 +122,20 @@ Check if the user is a desktop.
 
 Check if the user is a robot.
 
-	Agent::isRobot();
+```php
+Agent::isRobot();
+```
 
 ### Browser/platform version
 
 MobileDetect recently added a `version` method that can get the version number for components. To get the browser or platform version you can use:
 
-	$browser = Agent::browser();
-	$version = Agent::version($browser);
+```php
+$browser = Agent::browser();
+$version = Agent::version($browser);
 
-	$platform = Agent::platform();
-	$version = Agent::version($platform);
+$platform = Agent::platform();
+$version = Agent::version($platform);
+```
 
 *Note, the version method is still in beta, so it might not return the correct result.*


### PR DESCRIPTION
Changed this:

	'Jenssegers\Agent\AgentServiceProvider',

Into this:
```php
'Jenssegers\Agent\AgentServiceProvider',
```